### PR TITLE
Added the code of an existing commit with the comment "Fix for Intell…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <org.mapstruct.version>1.2.0.CR2</org.mapstruct.version>
+        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <m2e.apt.activation>jdt_apt</m2e.apt.activation>
     </properties>
 
     <dependencies>
@@ -53,6 +54,14 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct-jdk8</artifactId>
             <version>${org.mapstruct.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${org.mapstruct.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -100,7 +109,7 @@
                     </annotationProcessorPaths>
                     <compilerArgs>
                         <compilerArg>
-                               -Amapstruct.defaultComponentModel=spring
+                            -Amapstruct.defaultComponentModel=spring
                         </compilerArg>
                     </compilerArgs>
                 </configuration>


### PR DESCRIPTION
Hi here i propose this fix for the branch patch-customer with the fix that i have founded in branch update-customer in the commit with the comment "Fix for Intellij / Mapstuct annotation processing and workaround of constructor autowiring in CustomerServiceImpl"
![image](https://user-images.githubusercontent.com/82389991/167313188-9fe3c366-0c1b-436b-a035-e5e4345bf9fc.png)
This fix solve the following error build failed : CategoryMapperImpl is not generated in the directory /target by MapStruct !
![image](https://user-images.githubusercontent.com/82389991/167313257-ed351e0f-088c-41f4-9514-8607b43ff074.png)
This problem is also present the following branches and could be corrected by the same patch.